### PR TITLE
feature/EVOL-1254-purchase-context

### DIFF
--- a/example/example.php
+++ b/example/example.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../src/Entity/Quote.php';
 require_once __DIR__ . '/../src/Entity/Site.php';
 require_once __DIR__ . '/../src/Entity/Template.php';
 require_once __DIR__ . '/../src/Entity/User.php';
+require_once __DIR__ . '/../src/Entity/Purchase.php';
 require_once __DIR__ . '/../src/Helper/SingletonTrait.php';
 require_once __DIR__ . '/../src/Context/ApplicationContext.php';
 require_once __DIR__ . '/../src/Repository/Repository.php';
@@ -18,6 +19,7 @@ require_once __DIR__ . '/../src/Repository/SiteRepository.php';
 require_once __DIR__ . '/../src/Helper/PlaceholderReplacer.php';
 require_once __DIR__ . '/../src/Helper/QuotePlaceholderReplacer.php';
 require_once __DIR__ . '/../src/Helper/UserPlaceholderReplacer.php';
+require_once __DIR__ . '/../src/Helper/PurchasePlaceholderReplacer.php';
 require_once __DIR__ . '/../src/TemplateManager.php';
 
 $faker = Factory::create();
@@ -28,6 +30,7 @@ $template = new Template(
     "
             Bonjour [user:first_name],
             <br>Merci de nous avoir contacté pour votre livraison à [quote:destination_name].
+            <br>Votre token d'achat est <b style='color:red'>[purchase:token]</b>.
             <br>Bien cordialement,
             <br>L'équipe de Shipper
 ");
@@ -35,16 +38,18 @@ $template = new Template(
 // Initialiser les placeholders
 $quoteReplacer = new QuotePlaceholderReplacer();
 $userReplacer = new UserPlaceholderReplacer();
+$purchaseReplacer = new PurchasePlaceholderReplacer();
 
 // Initialiser le TemplateManager
-$templateManager = new TemplateManager([$quoteReplacer, $userReplacer]);
+$templateManager = new TemplateManager([$quoteReplacer, $userReplacer, $purchaseReplacer]);
 
 // Calculer avec les données fournies
 $message = $templateManager->getTemplateComputed(
     $template,
     [
         'quote' => new Quote($faker->randomNumber(), $faker->randomNumber(), $faker->randomNumber(), $faker->date()),
-        'user' => new User($faker->randomNumber(), $faker->firstName, $faker->lastName, $faker->email)
+        'user' => new User($faker->randomNumber(), $faker->firstName, $faker->lastName, $faker->email),
+        'purchase' => new Purchase($faker->randomNumber(), $faker->uuid)
     ]
 );
 

--- a/src/Entity/Purchase.php
+++ b/src/Entity/Purchase.php
@@ -1,0 +1,13 @@
+<?php
+
+class Purchase
+{
+    public $id;
+    public $token;
+
+    public function __construct($id, $token)
+    {
+        $this->id = $id;
+        $this->token = $token;
+    }
+}

--- a/src/Helper/PurchasePlaceholderReplacer.php
+++ b/src/Helper/PurchasePlaceholderReplacer.php
@@ -1,0 +1,21 @@
+<?php
+
+class PurchasePlaceholderReplacer implements PlaceholderReplacer
+{
+    public function replacePlaceholders(string $content, array $placeholders): string
+    {
+        // Vérifier si les données valides
+        if (!isset($placeholders['purchase']) || !($placeholders['purchase'] instanceof Purchase)) {
+            return $content;
+        }
+
+        $purchase = $placeholders['purchase'];
+
+        // Remplacer les placeholders spécifiques à l'achat
+        if (strpos($content, '[purchase:token]') !== false) {
+            $content = str_replace('[purchase:token]', $purchase->token, $content);
+        }
+
+        return $content;
+    }
+}


### PR DESCRIPTION
Ajouter l'entité Purchase et le placeholders

- Ajout de la nouvelle entité Purchase pour représenter les données d'achat.
  - Purchase.php contient les propriétés id, token
  - Le constructeur initialise id, token.

- Implémentation de PurchasePlaceholderReplacer pour gérer les placeholders spécifiques aux achats.
  - PurchasePlaceholderReplacer.php implémente l'interface PlaceholderReplacer.
  - Remplace [purchase:token] dans le texte du template.

- Mise à jour de example.php pour démontrer l'utilisation de PurchasePlaceholderReplacer.
  - Inclusion de la nouvelle entité Purchase et de PurchasePlaceholderReplacer.
  - Ajout de données d'exemple pour Purchase dans l'appel de la méthode getTemplateComputed.
  - Le template inclut maintenant le placeholder [purchase:token] pour montrer la nouvelle fonctionnalité.

- Assure que TemplateManager peut gérer le nouveau remplaçant de placeholders.
  - Modification de TemplateManager pour accepter un tableau d'instances de PlaceholderReplacer.